### PR TITLE
docs(agents): Add PR Japanese accordion rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,3 +26,30 @@ function validateSettlement(order: Order, now: Date): boolean {
   // ...
 }
 ```
+
+## PR Description Rule (English + Japanese Accordion)
+
+When writing pull request descriptions, always write the main content in English, and include the Japanese version inside an accordion (`<details>` block).
+
+- Keep English as the primary body text.
+- Add a `## Japanese` section using `<details>` and `<summary>Japanese</summary>`.
+- Ensure the Japanese content matches the English content in meaning.
+
+Example:
+
+```md
+## Summary
+
+- Add validation for settlement windows.
+- Update unit tests for JP-specific cases.
+
+<details>
+<summary>Japanese</summary>
+
+## 日本語
+
+- 決済可能時間帯のバリデーションを追加。
+- 日本向けケースのユニットテストを更新。
+
+</details>
+```


### PR DESCRIPTION
## Summary

- Add a PR description guideline to `AGENTS.md` requiring English as the primary language.
- Add a Japanese translation section using a `<details>` accordion with `<summary>Japanese</summary>`.
- Include an example format so future PR descriptions stay consistent.

## Testing

- Not run (documentation-only change).

## Japanese

<details>
<summary>Japanese</summary>

- `AGENTS.md` に、PR本文を英語主体で記載するルールを追加。
- 日本語訳を `<details>` と `<summary>Japanese</summary>` のアコーディオンで併記するルールを追加。
- 今後のPR説明文の統一のため、記載例を追加。

### テスト

- 未実施（ドキュメント変更のみ）。

</details>
