### PR TITLE
feat(core): Add sessions list UI with search pin and label edit

### DIFF
--- a/src/screens/internal/SessionsScreen.tsx
+++ b/src/screens/internal/SessionsScreen.tsx
@@ -130,35 +130,38 @@ export function SessionsScreen() {
   const clientRef = useRef<GatewayClient | null>(null);
   const serviceRef = useRef<SessionsService | null>(null);
 
-  const refreshSessions = useCallback(async (useRefreshingState: boolean) => {
-    const service = serviceRef.current;
-    if (!service) {
-      throw new Error("Session service is not ready");
-    }
-
-    if (useRefreshingState) {
-      setIsRefreshing(true);
-    } else {
-      setIsLoading(true);
-    }
-    setErrorMessage("");
-
-    try {
-      const result = await service.listSessions();
-      setAllSessions(result);
-      if (result.length > 0 && !activeSessionKey) {
-        setActiveSessionKey(result[0]?.key ?? "");
+  const refreshSessions = useCallback(
+    async (useRefreshingState: boolean) => {
+      const service = serviceRef.current;
+      if (!service) {
+        throw new Error("Session service is not ready");
       }
-    } catch (error) {
-      setErrorMessage(error instanceof Error ? error.message : "Failed to load sessions");
-    } finally {
+
       if (useRefreshingState) {
-        setIsRefreshing(false);
+        setIsRefreshing(true);
       } else {
-        setIsLoading(false);
+        setIsLoading(true);
       }
-    }
-  }, [activeSessionKey]);
+      setErrorMessage("");
+
+      try {
+        const result = await service.listSessions();
+        setAllSessions(result);
+        if (result.length > 0 && !activeSessionKey) {
+          setActiveSessionKey(result[0]?.key ?? "");
+        }
+      } catch (error) {
+        setErrorMessage(error instanceof Error ? error.message : "Failed to load sessions");
+      } finally {
+        if (useRefreshingState) {
+          setIsRefreshing(false);
+        } else {
+          setIsLoading(false);
+        }
+      }
+    },
+    [activeSessionKey],
+  );
 
   const initialize = useCallback(async () => {
     setIsLoading(true);
@@ -232,14 +235,10 @@ export function SessionsScreen() {
           });
 
     if (tab === "pinned") {
-      return searched
-        .filter((item) => item.pinned)
-        .sort((a, b) => b.updatedAt - a.updatedAt);
+      return searched.filter((item) => item.pinned).sort((a, b) => b.updatedAt - a.updatedAt);
     }
     if (tab === "recent") {
-      return searched
-        .slice()
-        .sort((a, b) => b.updatedAt - a.updatedAt);
+      return searched.slice().sort((a, b) => b.updatedAt - a.updatedAt);
     }
     return searched;
   }, [allSessions, searchText, tab]);
@@ -414,7 +413,12 @@ export function SessionsScreen() {
         />
       )}
 
-      <Modal visible={Boolean(editingSession)} transparent animationType="fade" onRequestClose={() => setEditingSession(null)}>
+      <Modal
+        visible={Boolean(editingSession)}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setEditingSession(null)}
+      >
         <View style={styles.modalRoot}>
           <Pressable style={styles.modalBackdrop} onPress={() => setEditingSession(null)} />
           <View style={styles.modalSheet}>
@@ -441,7 +445,9 @@ export function SessionsScreen() {
                 onPress={() => void onSaveLabel()}
                 disabled={isSavingLabel}
               >
-                <Text style={styles.modalSaveText}>{isSavingLabel ? "Saving..." : "Save Changes"}</Text>
+                <Text style={styles.modalSaveText}>
+                  {isSavingLabel ? "Saving..." : "Save Changes"}
+                </Text>
               </Pressable>
             </View>
           </View>


### PR DESCRIPTION
## Summary

- Implement the `internal/sessions` screen UI based on Stitch `openpocket` session designs.
- Wire the screen to `SessionsService` to fetch `sessions.list`, support local pin toggling, and update labels via `sessions.patch`.
- Add stateful UI for loading, error, empty list, empty search result, and edit-label modal.
- Keep the active session selection in screen state to prepare for chat session switching.

## Testing

- `pnpm -s typecheck`
- `pnpm -s lint`
- `pnpm -s test`

## Related

- closes #8

<details>
<summary>Japanese</summary>

## 日本語

- Stitch の `openpocket` にある Sessions デザインをベースに、`internal/sessions` 画面UIを実装しました。
- `SessionsService` と連携し、`sessions.list` の取得、ローカルピン切替、`sessions.patch` によるラベル更新に対応しました。
- ローディング、エラー、空一覧、検索0件、ラベル編集モーダルの状態別UIを追加しました。
- Chat画面連携に向けて、選択中 session の状態管理を画面内に実装しました。

## テスト

- `pnpm -s typecheck`
- `pnpm -s lint`
- `pnpm -s test`

## 関連

- closes #8

</details>
