### PR TITLE
feat(core): Add Gateway chat backend service

### DIFF
--- a/src/core/chat/ChatService.ts
+++ b/src/core/chat/ChatService.ts
@@ -50,14 +50,22 @@ function isChatState(value: unknown): value is ChatEventPayload["state"] {
 }
 
 function parseHistoryResult(payload: unknown): ChatHistoryResult {
-  if (!isRecord(payload) || typeof payload.sessionKey !== "string" || !Array.isArray(payload.messages)) {
+  if (
+    !isRecord(payload) ||
+    typeof payload.sessionKey !== "string" ||
+    !Array.isArray(payload.messages)
+  ) {
     throw new Error("Invalid chat.history response payload");
   }
   return payload as ChatHistoryResult;
 }
 
 function parseSendAck(payload: unknown): ChatSendAck {
-  if (!isRecord(payload) || typeof payload.runId !== "string" || typeof payload.status !== "string") {
+  if (
+    !isRecord(payload) ||
+    typeof payload.runId !== "string" ||
+    typeof payload.status !== "string"
+  ) {
     throw new Error("Invalid chat.send response payload");
   }
   if (payload.status === "error") {
@@ -217,4 +225,3 @@ export class ChatService {
     return `${sessionKey}:${this.now()}:${this.randomId()}`;
   }
 }
-

--- a/src/core/chat/types.ts
+++ b/src/core/chat/types.ts
@@ -103,4 +103,3 @@ export type ChatEventPayload = {
  *                 生の Gateway イベント packet。
  */
 export type ChatEventListener = (payload: ChatEventPayload, packet: GatewayEventPacket) => void;
-

--- a/tests/chat-service.test.ts
+++ b/tests/chat-service.test.ts
@@ -203,7 +203,9 @@ describe("ChatService", () => {
     const requester = new MockRequester();
     const service = new ChatService(requester);
 
-    expect(() => service.onChatEvent(() => undefined)).toThrow("Chat event source is not configured");
+    expect(() => service.onChatEvent(() => undefined)).toThrow(
+      "Chat event source is not configured",
+    );
   });
 
   // chat.history payload が不正な場合はエラーにすること
@@ -217,4 +219,3 @@ describe("ChatService", () => {
     );
   });
 });
-


### PR DESCRIPTION
## Summary

- Add `ChatService` for backend-only Gateway chat operations used by Issue #9 scope.
- Add chat protocol types for `chat.history`, `chat.send`, `chat.abort`, and `event: "chat"` payloads.
- Add unit tests for history/send/abort flows and chat event subscription/filtering.
- Remove the temporary research document after implementation.

## What Changed

- Added `src/core/chat/types.ts`
  - Request/result/event types for chat-related Gateway methods.
- Added `src/core/chat/ChatService.ts`
  - `getHistory(params)` -> `chat.history`
  - `send(input)` -> `chat.send` with generated idempotency key fallback
  - `abort(params)` -> `chat.abort`
  - `onChatEvent(listener, filter)` for `event: "chat"` stream subscription
  - Runtime payload validation for request/response/event boundaries
- Added `tests/chat-service.test.ts`
  - Covers payload validation and normal flows
  - Covers event filtering by `sessionKey` and `runId`

## Testing

- `pnpm test tests/chat-service.test.ts tests/sessions-service.test.ts`
- `pnpm typecheck`

## Related

- Related to #9

<details>
<summary>Japanese</summary>

## 日本語

### 概要

- Issue #9 の backend 範囲に対応するため、Gateway chat 操作向けの `ChatService` を追加しました。
- `chat.history` / `chat.send` / `chat.abort` / `event: "chat"` の型を追加しました。
- history/send/abort と event 購読フィルタのユニットテストを追加しました。
- 実装後、調査用ドキュメントを削除しました。

### 変更内容

- `src/core/chat/types.ts` を追加
  - chat 関連メソッドの request/result/event 型を定義
- `src/core/chat/ChatService.ts` を追加
  - `getHistory(params)` -> `chat.history`
  - `send(input)` -> `chat.send`（idempotency key の自動生成を含む）
  - `abort(params)` -> `chat.abort`
  - `onChatEvent(listener, filter)` で `event: "chat"` を購読
  - request/response/event の境界で payload 検証を実施
- `tests/chat-service.test.ts` を追加
  - payload 検証と通常フローをテスト
  - `sessionKey` / `runId` フィルタをテスト

### テスト

- `pnpm test tests/chat-service.test.ts tests/sessions-service.test.ts`
- `pnpm typecheck`

### 関連

- #9 関連

</details>
